### PR TITLE
Avoid "Cannot read property 'set' of null" error

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ CacheStore.prototype.get = function (index, opts, cb) {
 
   self.store.get(index, function (err, buf) {
     if (err) return cb(err)
-    if (self.cache !== null) self.cache.set(index, buf)
+    if (self.cache != null) self.cache.set(index, buf)
     cb(null, opts ? buf.slice(start, end) : buf)
   })
 }

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ CacheStore.prototype.get = function (index, opts, cb) {
 
   self.store.get(index, function (err, buf) {
     if (err) return cb(err)
-    self.cache.set(index, buf)
+    if (self.cache !== null) self.cache.set(index, buf)
     cb(null, opts ? buf.slice(start, end) : buf)
   })
 }


### PR DESCRIPTION
When the store was destroyed or closed, the cache attribute is null