### PR TITLE
Fix cache concurrency and errors after destroy

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,12 +14,15 @@ class CacheStore {
   }
 
   put (index, buf, cb) {
+    if (!this.cache) return nextTick(cb, new Error('CacheStore closed'))
+
     this.cache.remove(index)
     this.store.put(index, buf, cb)
   }
 
   get (index, opts, cb) {
     if (typeof opts === 'function') return this.get(index, null, opts)
+    if (!this.cache) return nextTick(cb, new Error('CacheStore closed'))
 
     const start = (opts && opts.offset) || 0
     const end = opts && opts.length && (start + opts.length)
@@ -35,11 +38,15 @@ class CacheStore {
   }
 
   close (cb) {
+    if (!this.cache) return nextTick(cb, new Error('CacheStore closed'))
+
     this.cache = null
     this.store.close(cb)
   }
 
   destroy (cb) {
+    if (!this.cache) return nextTick(cb, new Error('CacheStore closed'))
+
     this.cache = null
     this.store.destroy(cb)
   }

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ class CacheStore {
   }
 
   put (index, buf, cb) {
+    this.cache.remove(index)
     this.store.put(index, buf, cb)
   }
 


### PR DESCRIPTION
* Without calling `this.cache.remove` in `put`, subsequent `get` calls may get old values out of the cache
* Calling methods after `close` or `destroy` should call the callback instead of throwing