### PR TITLE
Fix exception if get callback is called after destroy

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,6 @@ class CacheStore {
     if (!this.cache) return nextTick(cb, new Error('CacheStore closed'))
 
     this.cache = null
-    this.inProgressGets = null
     this.store.destroy(cb)
   }
 }


### PR DESCRIPTION
Previously, the line `const inProgressEntry = this.inProgressGets.get(index)` would throw if it was reached after destroy